### PR TITLE
34 Config loads secretsmanager.properties by context classloader

### DIFF
--- a/src/main/java/com/amazonaws/secretsmanager/util/Config.java
+++ b/src/main/java/com/amazonaws/secretsmanager/util/Config.java
@@ -67,7 +67,7 @@ public final class Config {
     private static Properties loadPropertiesFromConfigFile(String resourceName) {
         Properties newConfig = new Properties(System.getProperties());
 
-        try (InputStream configFile = ClassLoader.getSystemResourceAsStream(resourceName)) {
+        try (InputStream configFile = Thread.currentThread().getContextClassLoader().getResourceAsStream(resourceName)) {
             if (configFile != null) {
                 newConfig.load(configFile);
                 configFile.close();


### PR DESCRIPTION
*Issue #:* 34

*Description of changes:*
Config class uses thread context class loader instead of system class loader to load property file. Tested on a Tomcat instance in AWS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
